### PR TITLE
fix: plural form to match naming of other packages

### DIFF
--- a/src/templates/network.ts
+++ b/src/templates/network.ts
@@ -57,12 +57,12 @@ export default (chain: string, version: string): NetworkTemplate => {
   return {
     source: source(firstLetterToUpperCase(chain)),
     pkg: PackageJson(
-      `@liquality/${firstLetterToLowerCase(chain)}-network`,
+      `@liquality/${firstLetterToLowerCase(chain)}-networks`,
       version,
       dependencies(version),
-      `Network specific settings for ${firstLetterToUpperCase(chain)}`
+      `Networks specific settings for ${firstLetterToUpperCase(chain)}`
     ),
-    folder: `${firstLetterToLowerCase(chain)}-network`,
+    folder: `${firstLetterToLowerCase(chain)}-networks`,
     fileName: `index.ts`,
   };
 };


### PR DESCRIPTION
Small improvement related to consistent package naming:
- _network folder_ will be in plural form to match previously created network packages
- _package.json_ field _name_ will be in a plural form